### PR TITLE
feat: update vite-config / remove editor styles wrapper from theme /

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@yardinternet/prettier-config": "^1.1.2",
 		"@yardinternet/stylelint-config": "^1.1.2",
 		"@yardinternet/toolkit": "^1.1.10",
-		"@yardinternet/vite-config": "^1.0.7",
+		"@yardinternet/vite-config": "^1.0.10",
 		"tailwindcss": "^4.1.13",
 		"vite": "^7.1.3"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         specifier: ^1.1.10
         version: 1.1.11(@babel/core@7.28.5)(@types/eslint@9.6.1)(@typescript-eslint/parser@6.21.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(jiti@1.21.7)(postcss@8.5.6)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@1.21.7)(lightningcss@1.30.2)(sass@1.97.1)(terser@5.44.1))(webpack@5.104.1)
       '@yardinternet/vite-config':
-        specifier: ^1.0.7
+        specifier: ^1.0.10
         version: 1.0.10(postcss@8.5.6)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@1.21.7)(lightningcss@1.30.2)(sass@1.97.1)(terser@5.44.1))(webpack@5.104.1)
       tailwindcss:
         specifier: ^4.1.13

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,4 +11,5 @@ export default braveConfig( {
 		'resources/styles/editor.css',
 		'resources/styles/frontend.css',
 	],
+	editorStylesPrefixWrap: { entryPoints: [ 'resources/styles/editor.css' ] },
 } );

--- a/web/app/themes/sage/resources/styles/editor.css
+++ b/web/app/themes/sage/resources/styles/editor.css
@@ -2,46 +2,40 @@
 
 /* Base */
 @import './base/variables';
+@import './base/base';
 @import './base/base-editor';
 @import './base/utilities';
 
-/* Footer */
+/* Components */
+@import './components/cards';
 @import './components/footer';
+@import './components/forms';
+@import './components/gravity-forms';
 
-.editor-styles-wrapper {
-	/* Base */
-	@import './base/base';
+/* Elements */
+@import './elements/lists';
 
-	/* Components */
-	@import './components/cards';
-	@import './components/forms';
-	@import './components/gravity-forms';
+/* Blocks */
+@import './blocks/breadcrumbs/shared';
+@import './blocks/button/shared';
+@import './blocks/collapse/editor';
+@import './blocks/collapse/shared';
+@import './blocks/columns/shared';
+@import './blocks/file/editor';
+@import './blocks/file/shared';
+@import './blocks/group/shared';
+@import './blocks/iconlist/shared';
+@import './blocks/media-text/shared';
+@import './blocks/quote/shared';
+@import './blocks/social-link/shared';
+@import './blocks/spacer/editor';
+@import './blocks/table/editor';
+@import './blocks/table/shared';
+@import './blocks/tabs/shared';
+@import './blocks/tabs/editor';
+@import './blocks/timeline/shared';
+@import './blocks/timeline/editor';
+@import './blocks/wp/shared';
 
-	/* Elements */
-	@import './elements/lists';
-
-	/* Blocks */
-	@import './blocks/breadcrumbs/shared';
-	@import './blocks/button/shared';
-	@import './blocks/collapse/editor';
-	@import './blocks/collapse/shared';
-	@import './blocks/columns/shared';
-	@import './blocks/file/editor';
-	@import './blocks/file/shared';
-	@import './blocks/group/shared';
-	@import './blocks/iconlist/shared';
-	@import './blocks/media-text/shared';
-	@import './blocks/quote/shared';
-	@import './blocks/social-link/shared';
-	@import './blocks/spacer/editor';
-	@import './blocks/table/editor';
-	@import './blocks/table/shared';
-	@import './blocks/tabs/shared';
-	@import './blocks/tabs/editor';
-	@import './blocks/timeline/shared';
-	@import './blocks/timeline/editor';
-	@import './blocks/wp/shared';
-
-	/* Layouts */
-	@import './layouts/alignments';
-}
+/* Layouts */
+@import './layouts/alignments';


### PR DESCRIPTION
Het wrappen van de editor styles zit al in het vite-config package (vandaar de update). Deze PR verwijdert de originele .editor-styles-wrapper uit editor.css en schakelt het wrappen van de editor styles in vanuit de vite config in vite.config.js.