### PR TITLE
fix: bedrock autoloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 web/app/plugins/*
 !web/app/plugins/.gitkeep
 web/app/mu-plugins/*
+!web/app/mu-plugins/bedrock-autoloader.php
 web/app/themes/twentytwentyfour/
 web/app/upgrade
 web/app/uploads/*

--- a/web/app/mu-plugins/bedrock-autoloader.php
+++ b/web/app/mu-plugins/bedrock-autoloader.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Plugin Name:  Bedrock Autoloader
+ * Plugin URI:   https://github.com/roots/bedrock-autoloader
+ * Description:  An autoloader that enables standard plugins to be required just like must-use plugins. The autoloaded plugins are included during mu-plugin loading. An asterisk (*) next to the name of the plugin designates the plugins that have been autoloaded.
+ * Author:       Roots
+ * Author URI:   https://roots.io/
+ * License:      MIT License
+ */
+
+namespace Roots\Bedrock;
+
+if (is_blog_installed() && class_exists(Autoloader::class)) {
+	new Autoloader();
+}


### PR DESCRIPTION
@FreakyWizard I think this file was accidentally removed when moving this repo?

* Added `web/app/mu-plugins/bedrock-autoloader.php`, which registers the Bedrock Autoloader plugin to autoload standard plugins alongside must-use plugins.

More info on what this file: https://roots.io/bedrock/docs/mu-plugin-autoloader/