### PR TITLE
Feat/refactor list styling

### DIFF
--- a/web/app/themes/sage/resources/scripts/editor/block-styles.js
+++ b/web/app/themes/sage/resources/scripts/editor/block-styles.js
@@ -11,9 +11,18 @@ const buttonStyles = [
 	},
 ];
 
+const listStyles = [
+	{
+		label: 'Stijlloos',
+		name: 'unstyled',
+	},
+];
+
 domReady( () => {
 	// Register block styles
 	buttonStyles.forEach( ( style ) =>
 		registerBlockStyle( 'core/button', style )
 	);
+
+	listStyles.forEach( ( style ) => registerBlockStyle( 'core/list', style ) );
 } );

--- a/web/app/themes/sage/resources/scripts/editor/block-styles.js
+++ b/web/app/themes/sage/resources/scripts/editor/block-styles.js
@@ -11,15 +11,9 @@ const buttonStyles = [
 	},
 ];
 
-const listStyles = [
-	{
-		label: 'Stijlloos',
-		name: 'unstyled',
-	},
-];
-
 domReady( () => {
 	// Register block styles
-	registerBlockStyle( 'core/button', buttonStyles );
-	registerBlockStyle( 'core/list', listStyles );
+	buttonStyles.forEach( ( style ) =>
+		registerBlockStyle( 'core/button', style )
+	);
 } );

--- a/web/app/themes/sage/resources/scripts/editor/block-styles.js
+++ b/web/app/themes/sage/resources/scripts/editor/block-styles.js
@@ -4,25 +4,25 @@
 import { registerBlockStyle } from '@wordpress/blocks';
 import domReady from '@wordpress/dom-ready';
 
-const buttonStyles = [
-	{
-		label: 'Outline',
-		name: 'outlined',
-	},
-];
-
-const listStyles = [
-	{
-		label: 'Stijlloos',
-		name: 'unstyled',
-	},
-];
+const blockStyles = {
+	'core/button': [
+		{
+			name: 'outlined',
+			label: 'Outline',
+		},
+	],
+	'core/list': [
+		{
+			name: 'unstyled',
+			label: 'Stijlloos',
+		},
+	],
+};
 
 domReady( () => {
-	// Register block styles
-	buttonStyles.forEach( ( style ) =>
-		registerBlockStyle( 'core/button', style )
-	);
-
-	listStyles.forEach( ( style ) => registerBlockStyle( 'core/list', style ) );
+	Object.entries( blockStyles ).forEach( ( [ block, styles ] ) => {
+		styles.forEach( ( style ) => {
+			registerBlockStyle( block, style );
+		} );
+	} );
 } );

--- a/web/app/themes/sage/resources/styles/base/utilities.css
+++ b/web/app/themes/sage/resources/styles/base/utilities.css
@@ -217,10 +217,10 @@
 }
 
 @utility use-block-spacing {
-	@apply not-first:mbs-(--block-spacing-start) not-last:mbe-(--block-spacing-end);
+	@apply not-first:mt-(--block-spacing-top) not-last:mb-(--block-spacing-bottom);
 
 	/* Breadcrumb and headings control spacing between itself and adjacent blocks */
 	:is( .brave-breadcrumb, .wp-block-heading ) + & {
-		--block-spacing-start: 0 !important;
+		--block-spacing-top: 0 !important;
 	}
 }

--- a/web/app/themes/sage/resources/styles/base/utilities.css
+++ b/web/app/themes/sage/resources/styles/base/utilities.css
@@ -215,12 +215,3 @@
 	@apply fontawesome flex size-(--collapse-button-icon-size) items-center justify-center rounded-(--collapse-button-icon-radius) bg-(--collapse-button-icon-bg-color) leading-[inherit] text-(--collapse-button-icon-color) transition-all;
 	--fa-icon: var( --collapse-button-icon );
 }
-
-@utility use-block-spacing {
-	@apply not-first:mt-(--block-spacing-top) not-last:mb-(--block-spacing-bottom);
-
-	/* Breadcrumb and headings control spacing between itself and adjacent blocks */
-	:is( .brave-breadcrumb, .wp-block-heading ) + & {
-		--block-spacing-top: 0 !important;
-	}
-}

--- a/web/app/themes/sage/resources/styles/base/utilities.css
+++ b/web/app/themes/sage/resources/styles/base/utilities.css
@@ -215,3 +215,12 @@
 	@apply fontawesome flex size-(--collapse-button-icon-size) items-center justify-center rounded-(--collapse-button-icon-radius) bg-(--collapse-button-icon-bg-color) leading-[inherit] text-(--collapse-button-icon-color) transition-all;
 	--fa-icon: var( --collapse-button-icon );
 }
+
+@utility use-block-spacing {
+	@apply not-first:mbs-(--block-spacing-start) not-last:mbe-(--block-spacing-end);
+
+	/* Breadcrumb and headings control spacing between itself and adjacent blocks */
+	:is( .brave-breadcrumb, .wp-block-heading ) + & {
+		--block-spacing-start: 0 !important;
+	}
+}

--- a/web/app/themes/sage/resources/styles/blocks/timeline/shared.css
+++ b/web/app/themes/sage/resources/styles/blocks/timeline/shared.css
@@ -51,7 +51,7 @@
 }
 
 .wp-block-yard-timeline-item-collapse__summary {
-	@apply relative min-h-8 cursor-pointer list-none pr-10;
+	@apply relative min-h-8 cursor-pointer pr-10;
 
 	&::-webkit-details-marker {
 		@apply hidden;

--- a/web/app/themes/sage/resources/styles/components/mobile-menu.css
+++ b/web/app/themes/sage/resources/styles/components/mobile-menu.css
@@ -32,7 +32,7 @@
 	}
 
 	.sub-menu {
-		@apply mb-2 hidden list-none px-3;
+		@apply mb-2 hidden px-3;
 
 		.menu-item {
 			&.current-menu-item > a {

--- a/web/app/themes/sage/resources/styles/components/nav.css
+++ b/web/app/themes/sage/resources/styles/components/nav.css
@@ -51,7 +51,7 @@
 	}
 
 	.sub-menu {
-		@apply invisible absolute mb-0 min-w-max -translate-y-3 list-none bg-white pl-0 opacity-0 shadow-md transition-all ease-base;
+		@apply invisible absolute mb-0 min-w-max -translate-y-3 bg-white opacity-0 shadow-md transition-all ease-base;
 
 		.menu-item {
 			a {

--- a/web/app/themes/sage/resources/styles/elements/lists.css
+++ b/web/app/themes/sage/resources/styles/elements/lists.css
@@ -1,54 +1,39 @@
-ul,
-ol {
-	@apply mb-6 pl-8;
-
-	ul,
-	ol {
-		@apply mb-0;
-	}
+:root {
+	--list-block-spacing-end: 1.5rem;
+	--list-block-spacing-start: 1.5rem;
+	--list-indent: 1.5rem;
+	--list-spacing: 0.5rem;
 }
 
-ul {
-	@apply list-disc;
+.wp-block-list {
+	@apply list-(--list-type) space-y-(--list-spacing) pl-(--list-indent) not-first:mt-(--list-block-spacing-start) not-last:mb-(--list-block-spacing-end);
 
-	li::marker {
-		@apply text-primary;
+	&:is( ol ) {
+		--list-type: decimal;
+	}
+
+	&:is( ul ) {
+		--list-type: disc;
+	}
+
+	ol {
+		--list-type: lower-alpha;
 	}
 
 	ul {
-		@apply list-[circle];
-
-		ul {
-			@apply list-[square];
-		}
+		--list-type: circle;
 	}
-}
 
-ol {
-	@apply list-decimal;
-
-	ol {
-		@apply list-[lower-alpha];
+	:is( ol, ul ) {
+		--list-block-spacing-start: var( --list-spacing );
+		--list-block-spacing-end: 0;
 
 		ol {
-			@apply list-[lower-roman];
+			--list-type: lower-roman;
 		}
-	}
-}
 
-ul.is-style-unstyled,
-ol.is-style-unstyled {
-	@apply list-none p-0;
-
-	li {
-		@apply mb-1;
-
-		a {
-			@apply text-black no-underline;
-
-			@variant hocus {
-				@apply underline;
-			}
+		ul {
+			--list-type: square;
 		}
 	}
 }

--- a/web/app/themes/sage/resources/styles/elements/lists.css
+++ b/web/app/themes/sage/resources/styles/elements/lists.css
@@ -30,7 +30,8 @@
 		--list-type: var( --list-type-ul-level-2 );
 	}
 
-	:is( ol, ul ) {
+	ol,
+	ul {
 		@apply mt-(--list-spacing) mb-0;
 
 		ol {
@@ -46,7 +47,8 @@
 		@apply list-none;
 		--list-indent: 0;
 
-		:is( ol, ul ) {
+		ol,
+		ul {
 			@apply list-none;
 		}
 	}

--- a/web/app/themes/sage/resources/styles/elements/lists.css
+++ b/web/app/themes/sage/resources/styles/elements/lists.css
@@ -36,4 +36,13 @@
 			--list-type: square;
 		}
 	}
+
+	&.is-style-unstyled {
+		@apply list-none;
+		--list-indent: 0;
+
+		:is( ol, ul ) {
+			@apply list-none;
+		}
+	}
 }

--- a/web/app/themes/sage/resources/styles/elements/lists.css
+++ b/web/app/themes/sage/resources/styles/elements/lists.css
@@ -5,8 +5,8 @@
 
 .wp-block-list {
 	@apply use-block-spacing list-(--list-type) space-y-(--list-spacing) pl-(--list-indent);
-	--block-spacing-start: 1.5rem;
-	--block-spacing-end: 1.5rem;
+	--block-spacing-top: 1.5rem;
+	--block-spacing-bottom: 1.5rem;
 
 	&:is( ol ) {
 		--list-type: decimal;
@@ -25,8 +25,8 @@
 	}
 
 	:is( ol, ul ) {
-		--block-spacing-start: var( --list-spacing );
-		--block-spacing-end: 0;
+		--block-spacing-top: var( --list-spacing );
+		--block-spacing-bottom: 0;
 
 		ol {
 			--list-type: lower-roman;

--- a/web/app/themes/sage/resources/styles/elements/lists.css
+++ b/web/app/themes/sage/resources/styles/elements/lists.css
@@ -1,39 +1,44 @@
 :root {
+	--list-block-spacing-bottom: 1.5rem;
+	--list-block-spacing-top: 1.5rem;
 	--list-indent: 1.5rem;
 	--list-spacing: 0.5rem;
+	--list-type-ol-level-1: decimal;
+	--list-type-ol-level-2: lower-alpha;
+	--list-type-ol-level-3: lower-roman;
+	--list-type-ul-level-1: disc;
+	--list-type-ul-level-2: circle;
+	--list-type-ul-level-3: square;
 }
 
 .wp-block-list {
-	@apply use-block-spacing list-(--list-type) space-y-(--list-spacing) pl-(--list-indent);
-	--block-spacing-top: 1.5rem;
-	--block-spacing-bottom: 1.5rem;
+	@apply mt-(--list-block-spacing-top) mb-(--list-block-spacing-bottom) flex list-(--list-type) flex-col gap-(--list-spacing) pl-(--list-indent);
 
 	&:is( ol ) {
-		--list-type: decimal;
+		--list-type: var( --list-type-ol-level-1 );
 	}
 
 	&:is( ul ) {
-		--list-type: disc;
+		--list-type: var( --list-type-ul-level-1 );
 	}
 
 	ol {
-		--list-type: lower-alpha;
+		--list-type: var( --list-type-ol-level-2 );
 	}
 
 	ul {
-		--list-type: circle;
+		--list-type: var( --list-type-ul-level-2 );
 	}
 
 	:is( ol, ul ) {
-		--block-spacing-top: var( --list-spacing );
-		--block-spacing-bottom: 0;
+		@apply mt-(--list-spacing) mb-0;
 
 		ol {
-			--list-type: lower-roman;
+			--list-type: var( --list-type-ol-level-3 );
 		}
 
 		ul {
-			--list-type: square;
+			--list-type: var( --list-type-ul-level-3 );
 		}
 	}
 

--- a/web/app/themes/sage/resources/styles/elements/lists.css
+++ b/web/app/themes/sage/resources/styles/elements/lists.css
@@ -1,12 +1,12 @@
 :root {
-	--list-block-spacing-end: 1.5rem;
-	--list-block-spacing-start: 1.5rem;
 	--list-indent: 1.5rem;
 	--list-spacing: 0.5rem;
 }
 
 .wp-block-list {
-	@apply list-(--list-type) space-y-(--list-spacing) pl-(--list-indent) not-first:mt-(--list-block-spacing-start) not-last:mb-(--list-block-spacing-end);
+	@apply use-block-spacing list-(--list-type) space-y-(--list-spacing) pl-(--list-indent);
+	--block-spacing-start: 1.5rem;
+	--block-spacing-end: 1.5rem;
 
 	&:is( ol ) {
 		--list-type: decimal;
@@ -25,8 +25,8 @@
 	}
 
 	:is( ol, ul ) {
-		--list-block-spacing-start: var( --list-spacing );
-		--list-block-spacing-end: 0;
+		--block-spacing-start: var( --list-spacing );
+		--block-spacing-end: 0;
 
 		ol {
 			--list-type: lower-roman;

--- a/web/app/themes/sage/resources/styles/elements/lists.css
+++ b/web/app/themes/sage/resources/styles/elements/lists.css
@@ -3,31 +3,25 @@
 	--list-block-spacing-top: 1.5rem;
 	--list-indent: 1.5rem;
 	--list-spacing: 0.5rem;
-	--list-type-ol-level-1: decimal;
-	--list-type-ol-level-2: lower-alpha;
-	--list-type-ol-level-3: lower-roman;
-	--list-type-ul-level-1: disc;
-	--list-type-ul-level-2: circle;
-	--list-type-ul-level-3: square;
 }
 
 .wp-block-list {
 	@apply mt-(--list-block-spacing-top) mb-(--list-block-spacing-bottom) flex list-(--list-type) flex-col gap-(--list-spacing) pl-(--list-indent);
 
 	&:is( ol ) {
-		--list-type: var( --list-type-ol-level-1 );
+		--list-type: decimal;
 	}
 
 	&:is( ul ) {
-		--list-type: var( --list-type-ul-level-1 );
+		--list-type: disc;
 	}
 
 	ol {
-		--list-type: var( --list-type-ol-level-2 );
+		--list-type: lower-alpha;
 	}
 
 	ul {
-		--list-type: var( --list-type-ul-level-2 );
+		--list-type: circle;
 	}
 
 	ol,
@@ -35,11 +29,11 @@
 		@apply mt-(--list-spacing) mb-0;
 
 		ol {
-			--list-type: var( --list-type-ol-level-3 );
+			--list-type: lower-roman;
 		}
 
 		ul {
-			--list-type: var( --list-type-ul-level-3 );
+			--list-type: square;
 		}
 	}
 

--- a/web/app/themes/sage/resources/views/components/header/mobile-menu.blade.php
+++ b/web/app/themes/sage/resources/views/components/header/mobile-menu.blade.php
@@ -35,7 +35,7 @@
 			        'container' => '',
 			        'depth' => 2,
 			        'id' => '',
-			        'menu_class' => 'mobile-menu-navigation w-full mb-0 list-none px-4',
+			        'menu_class' => 'mobile-menu-navigation w-full px-4',
 			        'theme_location' => 'primary_navigation',
 			    ]);
 			}
@@ -45,7 +45,7 @@
 			        'container' => '',
 			        'depth' => 1,
 			        'id' => '',
-			        'menu_class' => 'mobile-menu-navigation mobile-menu-top-bar w-full mb-0 list-none px-4',
+			        'menu_class' => 'mobile-menu-navigation mobile-menu-top-bar w-full px-4',
 			        'theme_location' => 'top_bar_navigation',
 			    ]);
 			}

--- a/web/app/themes/sage/resources/views/components/header/navigation.blade.php
+++ b/web/app/themes/sage/resources/views/components/header/navigation.blade.php
@@ -5,7 +5,7 @@
 			    'container' => '',
 			    'depth' => 2,
 			    'id' => '',
-			    'menu_class' => 'nav pl-0 flex align-center justify-center list-none h-full mb-0',
+			    'menu_class' => 'nav flex align-center justify-center h-full',
 			    'theme_location' => 'primary_navigation',
 			]);
 		@endphp

--- a/web/app/themes/sage/resources/views/components/header/top-bar.blade.php
+++ b/web/app/themes/sage/resources/views/components/header/top-bar.blade.php
@@ -1,13 +1,14 @@
 @if (has_nav_menu('top_bar_navigation'))
 	<div class="top-bar h-(--top-bar-height) hidden bg-gray-100 lg:flex">
 		<div class="container h-full">
-			<nav class="flex h-full items-center justify-end text-sm" aria-label="{{ __('Secundaire navigatie', 'sage') }}">
+			<nav class="flex h-full items-center justify-end text-sm"
+				aria-label="{{ __('Secundaire navigatie', 'sage') }}">
 				@php
 					wp_nav_menu([
 					    'container' => '',
 					    'depth' => 1,
 					    'id' => '',
-					    'menu_class' => 'flex items-center list-none h-full m-0 p-0 gap-4',
+					    'menu_class' => 'flex items-center h-full gap-4',
 					    'theme_location' => 'top_bar_navigation',
 					]);
 				@endphp

--- a/web/app/themes/sage/resources/views/components/layout/index.blade.php
+++ b/web/app/themes/sage/resources/views/components/layout/index.blade.php
@@ -8,32 +8,32 @@
 </head>
 
 <body <?php body_class(); ?>>
-	<?php wp_body_open(); ?>
-	<?php do_action('get_header'); ?>
+<?php wp_body_open(); ?>
+<?php do_action('get_header'); ?>
 
-	<div id="app" class="flex min-h-screen flex-col overflow-x-clip">
-		<a class="is-button on-focus-visible focus:fixed! focus:left-4! focus:top-4!" href="#main">
-			{{ __('Skip to content') }}
-		</a>
+<div id="app" class="flex min-h-screen flex-col overflow-x-clip">
+	<a class="is-button on-focus-visible focus:fixed! focus:left-4! focus:top-4!" href="#main">
+		{{ __('Skip to content') }}
+	</a>
 
-		@include('sections.header')
+	@include('sections.header')
 
-		<main id="main" class="main is-main-content create-main-content-alignment mt-(--combined-bar-height) flex-auto">
-			@if (post_password_required())
-				@php(the_content())
-			@else
-				<x-brave-breadcrumb class="container py-3 text-sm" listClass="align-items-center flex list-none flex-wrap pl-0 mb-0"
-					itemClass="not-last:after:content-['|'] after:mx-2 text-gray-500"
-					linkClass="inline-block text-black no-underline hocus:text-primary focus:underline" />
-				{{ $slot }}
-			@endif
-		</main>
+	<main id="main" class="main is-main-content create-main-content-alignment mt-(--combined-bar-height) flex-auto">
+		@if (post_password_required())
+			@php(the_content())
+		@else
+			<x-brave-breadcrumb class="container py-3 text-sm" listClass="align-items-center flex flex-wrap"
+				itemClass="not-last:after:content-['|'] after:mx-2 text-gray-500"
+				linkClass="inline-block text-black no-underline hocus:text-primary focus:underline" />
+			{{ $slot }}
+		@endif
+	</main>
 
-		@include('sections.footer')
-	</div>
+	@include('sections.footer')
+</div>
 
-	<?php do_action('get_footer'); ?>
-	<?php wp_footer(); ?>
+<?php do_action('get_footer'); ?>
+<?php wp_footer(); ?>
 </body>
 
 </html>

--- a/web/app/themes/sage/resources/views/components/meta/list.blade.php
+++ b/web/app/themes/sage/resources/views/components/meta/list.blade.php
@@ -1,3 +1,3 @@
-<ul {{ $attributes->merge(['class' => 'meta-list flex flex-col list-none flex-wrap gap-x-8 gap-y-2 pl-0']) }}>
+<ul {{ $attributes->merge(['class' => 'meta-list flex flex-col flex-wrap gap-x-8 gap-y-2']) }}>
 	{{ $slot }}
 </ul>

--- a/web/app/themes/sage/resources/views/sections/footer.blade.php
+++ b/web/app/themes/sage/resources/views/sections/footer.blade.php
@@ -14,7 +14,7 @@
 						    'container' => '',
 						    'depth' => 1,
 						    'id' => '',
-						    'menu_class' => 'footer-menu flex flex-wrap items-center list-none h-full m-0 p-0 gap-x-3 gap-y-1',
+						    'menu_class' => 'footer-menu flex flex-wrap items-center h-full gap-x-3 gap-y-1',
 						    'theme_location' => 'footer_navigation',
 						]);
 					@endphp


### PR DESCRIPTION
Tailwind Preflight reset lijsten standaard, dus geen markers, margin en padding. Onze list styling wordt toegepast op alle lijsten, waardoor we het werk van de reset ongedaan maken en op veel plekken `list-none`, `m-0` en `pl-0` classes gebruiken om de lijst styling nogmaals ongedaan te maken.

Deze PR scoped de échte lijst styling binnen de `.wp-block-list` class en verwijdert alle handmatige resets op andere plekken in de code.

In sommige gevallen komen lijsten die wel markers moeten hebben niet uit het Gutenberg block, bijvoorbeeld omdat content uit een ander CMS is geïmporteerd. In dat soort gevallen zou de selecter uitgebreid kunnen worden o.b.v. een specifieke class, bijvoorbeeld `.wysiwyg-content :is(ol, ul)`.

<img width="889" height="862" alt="Screenshot 2026-03-24 at 15 05 12" src="https://github.com/user-attachments/assets/ca404685-4007-4299-9bf9-25000ac3613f" />
