### PR TITLE
feat: security update pnpm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,10 @@ registry=https://registry.npmjs.org
 
 # Scoped package registry for @yardinternet
 @yardinternet:registry=https://npm.pkg.github.com
+
+# Prevent updating to releases younger than 7 days
+minimum-release-age=10080
+
+# Prevent running scripts during installation to avoid potential security risks
+ignore-scripts=true
+

--- a/.npmrc
+++ b/.npmrc
@@ -7,6 +7,6 @@ registry=https://registry.npmjs.org
 # Prevent updating to releases younger than 7 days
 minimum-release-age=10080
 
-# Prevent running scripts during installation to avoid potential security risks
-ignore-scripts=true
+# Exclude own packages from minimum release age check
+minimum-release-age-exclude=@yardinternet
 


### PR DESCRIPTION
## Wat is er veranderd

`.npmrc` krijgt een paar security instellingen om het risico op supply chain aanvallen te verkleinen.

## Waarom

Er was recent een aanval op het `axios` npm pakket waarbij compromised versies een Remote Access Trojan installeerden:
https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan

Op HackerNews kwam een goede tip voorbij:
https://news.ycombinator.com/item?id=47582632

> SA: npm/bun/pnpm/uv now all support setting a minimum release age for packages.
> I also have `ignore-scripts=true` in my ~/.npmrc. Based on the analysis, that alone would have mitigated the vulnerability. bun and pnpm do not execute lifecycle scripts by default.
>
> Here's how to set global configs to set min release age to 7 days:
>
> ```
> ~/.config/uv/uv.toml
> exclude-newer = "7 days"
>
> ~/.npmrc
> min-release-age=7 # days
> ignore-scripts=true
>
> ~/Library/Preferences/pnpm/rc
> minimum-release-age=10080 # minutes
>
> ~/.bunfig.toml
> [install]
> minimumReleaseAge = 604800 # seconds
> ```

Met een minimum release age blokkeer je pakketten die net gepubliceerd zijn. Hiermee voorkom je dat jij toevallig net pnpm update draait, terwijl 30 minuten geleden een package gehackt is. Als een breach niet binnen 7 dagen ontdekt word, hebben we een groter probleem haha :P 

Gecombineerd met `ignore-scripts=true` haal je al een hoop risico weg. 