### PR TITLE
fix: restore widgets theme support for WP Customizer

### DIFF
--- a/web/app/themes/sage/app/Hooks/Setup.php
+++ b/web/app/themes/sage/app/Hooks/Setup.php
@@ -71,11 +71,21 @@ class Setup
 			'style',
 		]);
 
+		// Required for the Customizer's Widgets panel. The menu item is hidden via removeWidgetsMenuItem().
+		add_theme_support('widgets');
+
 		/**
 		 * Enable selective refresh for widgets in customizer.
 		 *
 		 * @link https://developer.wordpress.org/reference/functions/add_theme_support/#customize-selective-refresh-widgets
 		 */
 		add_theme_support('customize-selective-refresh-widgets');
+	}
+
+	// Hides the Widgets menu item — widgets support itself is still enabled via themeSupport().
+	#[Action('admin_menu')]
+	public function removeWidgetsMenuItem(): void
+	{
+		remove_submenu_page('themes.php', 'widgets.php');
 	}
 }


### PR DESCRIPTION
## Probleem : Wp Customizer werkte niet meer
<img width="1722" height="753" alt="image" src="https://github.com/user-attachments/assets/813ffe41-e1d3-4c75-aecb-80edee3d5d83" />

1. Op een bepaald moment tijdens initialisatie is de titel van een paneel "null", hier komt een warning
voor.
2. Maar sinds Acorn warnings converteert naar exceptions, crasht nu de pagina.
3. Mogelijk was dit altijd al zo maar merkten we het niet omdat je voorheen enkel een warning kreeg.
4. In development converteert Acorn dus warnings naar exceptions, maar in productie blijft het een
warning. Daarom kon je tijdelijk het fixen door je WP_ENV te veranderen. (Al gingen dan wel opeens al
je assets fout.)

## Waarom werkte het vroeger wel?

Vroeger toen we nog footer deden via het "widgets menu" (`038ec906 refactor: setup hooks`) stond er een `registerThemeSidebars()` methode die `register_sidebar()` aanriep voor de footer:

```php
#[Action('widgets_init')]
public function registerThemeSidebars(): void
{
    register_sidebar([
        'name' => __('Footer', 'sage'),
        'id'   => 'footer',
        ...
    ]);
}
```

`register_sidebar()` roept intern automatisch `add_theme_support('widgets')` aan. 
Toen we dit weghaalde omdat we nu de footer doen vannuit de patronen (`cfaa852b "remove sidebar widget"` )
verdween dus ook impliciet de widgets support die gebruikt werd door de customizer.

## De fix

In `Setup.php` expliciet `add_theme_support('widgets')` toevoegen. Dit zorgt ervoor dat de Customizer weer werkt zonder warnings, errors of `WP_ENV` shenanigans.

Het Widgets menu item onder Appearance is opnieuw verborgen via `remove_submenu_page()` in `removeWidgetsMenuItem()`

```
WordPress heeft wel aangegeven dat de Customizer in de toekomst depricated word, maar die dag is vandaag nog niet. So might as well put it back.
```