### PR TITLE
fix: dialogs on safari

### DIFF
--- a/web/app/themes/sage/resources/views/components/facetwp/mobile-filters.blade.php
+++ b/web/app/themes/sage/resources/views/components/facetwp/mobile-filters.blade.php
@@ -10,13 +10,13 @@
 </x-brave::dialog.trigger>
 
 <x-brave-dialog :id="$dialogId" :ariaLabel="$label" @class([
-	'transition-discrete max-h-3/4 mt-auto w-full max-w-full translate-y-full rounded-t-lg bg-white opacity-0 transition-all duration-300',
-	'backdrop:transition-discrete backdrop:pointer-events-none backdrop:bg-black/0 backdrop:transition-all backdrop:duration-300',
-	'starting:open:translate-y-full starting:open:opacity-0 starting:open:backdrop:bg-black/0',
-	'open:translate-y-0 open:opacity-100 open:backdrop:bg-black/50',
+	'transition-discrete z-1 max-h-3/4 mt-auto h-fit w-full max-w-full transform-[translateY(100%)] rounded-t-lg bg-white opacity-0 transition-all duration-500',
+	'backdrop:transition-discrete backdrop:pointer-events-none backdrop:bg-black/0 backdrop:transition-all backdrop:duration-500',
+	'starting:open:transform-[translateY(100%)] starting:open:opacity-0 starting:open:backdrop:bg-black/0',
+	'open:transform-[translateY(0)] open:opacity-100 open:backdrop:bg-black/50',
 ])>
-	<div class="flex h-full flex-col">
-		<div class="z-1 sticky top-0 flex items-center justify-between gap-2 border-b border-gray-100 bg-white p-4">
+	<div class="flex flex-col">
+		<div class="z-2 sticky top-0 flex items-center justify-between gap-2 border-b border-gray-100 bg-white p-4">
 			<h2 class="mb-0 text-base font-normal">{{ $label }}</h2>
 			<x-brave::dialog.trigger :dialogId="$dialogId"
 				class="leading-0 -m-2 flex size-[46px] items-center justify-center text-2xl">
@@ -29,7 +29,7 @@
 			<x-facetwp.filters :facets="$facets" />
 		</div>
 
-		<div class="sticky bottom-4 mt-auto flex gap-2 px-4">
+		<div class="z-2 sticky bottom-4 mt-auto flex gap-2 px-4">
 			<x-facetwp.reset-button />
 
 			<x-brave::dialog.trigger :dialogId="$dialogId" class="is-button w-full justify-center">

--- a/web/app/themes/sage/resources/views/components/header/mobile-menu.blade.php
+++ b/web/app/themes/sage/resources/views/components/header/mobile-menu.blade.php
@@ -14,10 +14,10 @@
 </x-brave::dialog.trigger>
 
 <x-brave-dialog :id="$dialogId" :ariaLabel="$label" @class([
-	'mobile-menu transition-discrete top-0 bottom-0 left-10 right-0 h-full max-h-full w-auto max-w-full translate-x-full bg-white opacity-0 transition-all duration-500',
+	'mobile-menu transition-discrete top-0 bottom-0 left-10 right-0 h-full max-h-full w-auto max-w-full transform-[translateX(100%)] bg-white opacity-0 transition-all duration-500',
 	'backdrop:transition-discrete backdrop:pointer-events-none backdrop:bg-black/0 backdrop:transition-all backdrop:duration-500',
-	'starting:open:translate-x-full starting:open:opacity-0 starting:open:backdrop:bg-black/0',
-	'open:translate-x-0 open:opacity-100 open:backdrop:bg-black/50',
+	'starting:open:transform-[translateX(100%)] starting:open:opacity-0 starting:open:backdrop:bg-black/0',
+	'open:transform-[translateX(0)] open:opacity-100 open:backdrop:bg-black/50',
 ])>
 	<div class="flex h-full flex-col">
 		<div class="z-1 sticky top-0 flex items-center justify-between gap-2 border-b border-gray-100 bg-white p-4">

--- a/web/app/themes/sage/resources/views/components/header/search-bar.blade.php
+++ b/web/app/themes/sage/resources/views/components/header/search-bar.blade.php
@@ -13,10 +13,10 @@
 </x-brave::dialog.trigger>
 
 <x-brave-dialog :id="$dialogId" :ariaLabel="__('Zoekbalk', 'sage')" @class([
-	'search-bar transition-discrete h-(--combined-bar-height) px-3 w-full max-w-full -translate-y-full bg-white opacity-0 transition-all duration-500',
+	'search-bar transition-discrete h-(--combined-bar-height) px-3 w-full max-w-full transform-[translateY(-100%)] bg-white opacity-0 transition-all duration-500',
 	'backdrop:transition-discrete backdrop:pointer-events-none backdrop:bg-black/0 backdrop:transition-all backdrop:duration-500',
-	'starting:open:-translate-y-full starting:open:opacity-0 starting:open:backdrop:bg-black/0',
-	'open:translate-y-0 open:opacity-100 open:backdrop:bg-black/50',
+	'starting:open:transform-[translateY(-100%)] starting:open:opacity-0 starting:open:backdrop:bg-black/0',
+	'open:transform-[translateY(0)] open:opacity-100 open:backdrop:bg-black/50',
 ])>
 	<form class="flex h-full w-full items-center justify-center gap-2" method="get" action="{{ esc_url(home_url('/')) }}">
 		<input id="js-brave-search-bar-input"


### PR DESCRIPTION
`translate-y-full` wordt onderwater `translate: 0 100%` en dat werkt blijkbaar niet goed op safari. Daarom doe ik nu `transform: translateY(100%)`. Ook moest de filters nog wat aanpassingen qua height en `z-1` krijgen. Waarom dit eerst wel goed heeft gewerkt is mij een raadsel.