### PR TITLE
chore: `multi-gitter-scripts/two-factor-install`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,129 +1,127 @@
 {
-	"name": "yard/brave",
-	"type": "project",
-	"license": "MIT",
-	"description": "WordPress boilerplate with Bedrock and Sage",
-	"support": {
-		"source": "https://github.com/yardinternet/brave"
-	},
-	"config": {
-		"optimize-autoloader": true,
-		"preferred-install": "dist",
-		"sort-packages": true,
-		"allow-plugins": {
-			"captainhook/hook-installer": true,
-			"composer/installers": true,
-			"dangoodman/composer-for-wordpress": true,
-			"roots/wordpress-core-installer": true
-		},
-		"platform": {
-			"php": "8.2"
-		}
-	},
-	"minimum-stability": "stable",
-	"prefer-stable": true,
-	"repositories": [
-		{
-			"type": "composer",
-			"url": "https://wpackagist.org",
-			"only": [
-				"wpackagist-plugin/*",
-				"wpackagist-theme/*"
-			]
-		}
-	],
-	"require": {
-		"php": ">=8.2",
-		"composer/installers": "^2.2",
-		"gravitykit/gravity-forms-zero-spam": "^1.7",
-		"johnbillion/user-switching": "^1.11",
-		"log1x/navi": "^3.1",
-		"log1x/poet": "^2.0",
-		"lukasbesch/bedrock-plugin-disabler": "^1.4",
-		"oscarotero/env": "^2.1",
-		"plugin/yard-gutenberg": "^1.5",
-		"roots/acorn": "^4.0",
-		"roots/bedrock-autoloader": "^1.0",
-		"roots/bedrock-disallow-indexing": "^2.0",
-		"roots/wordpress": "6.9.*",
-		"roots/wp-config": "^1.0",
-		"sentry/sentry-laravel": "^4.13",
-		"spatie/laravel-google-fonts": "^1.4",
-		"spatie/laravel-ignition": "^2.0",
-		"vlucas/phpdotenv": "^5.5",
-		"wp-cli/wp-cli-bundle": "^2.11",
-		"wp-media/imagify-plugin": "^2.2",
-		"wpackagist-plugin/cookie-law-info": "^3.2",
-		"wpackagist-plugin/relay": "^1.3",
-		"wpackagist-plugin/stream": "^4.0",
-		"wpackagist-plugin/wp-seopress": "^8.1",
-		"yard/brave-components": "^1.2",
-		"yard/brave-csp": "^1.0",
-		"yard/brave-hooks": "^2.0",
-		"yard/config-expander": "^1.0",
-		"yard/data": "^1.0",
-		"yard/multisite-url-fixer": "^1.0",
-		"yard/nutshell": "^2.1",
-		"yard/query-block": "^1.0",
-		"yard/webmanifest": "^1.0",
-		"yard/wp-block-registrar": "^1.0",
-		"yard/wp-database": "^1.0",
-		"yard/wp-user-roles": "^2.0",
-		"yoast/duplicate-post": "^4.6"
-	},
-	"require-dev": {
-		"captainhook/captainhook": "^5.24",
-		"captainhook/hook-installer": "^1.0",
-		"johnbillion/query-monitor": "^3.20",
-		"yard/brave-scaffold": "^2.0",
-		"yard/lando-brave": "^1.0",
-		"yard/php-cs-fixer-rules": "^1.0"
-	},
-	"suggest": {
-		"gravity/gravityforms": "",
-		"deliciousbrains-plugin/wp-migrate-db-pro": "",
-		"plugin/yard-dashboard": "",
-		"wpengine/advanced-custom-fields-pro": "",
-		"ypackagist/facetwp": "",
-		"ypackagist/searchwp": "",
-		"ypackagist/wp-seopress-pro": "",
-		"yard/wp-deployer": "dev"
-	},
-	"autoload": {
-		"psr-4": {
-			"App\\": "web/app/themes/sage/app/"
-		}
-	},
-	"extra": {
-		"acorn": {
-			"providers": [
-				"App\\Providers\\ThemeServiceProvider"
-			]
-		},
-		"installer-paths": {
-			"web/app/mu-plugins/{$name}/": [
-				"type:wordpress-muplugin"
-			],
-			"web/app/plugins/{$name}/": [
-				"type:wordpress-plugin"
-			],
-			"web/app/themes/{$name}/": [
-				"type:wordpress-theme"
-			]
-		},
-		"wordpress-install-dir": "web/wp"
-	},
-	"scripts": {
-		"format": "./vendor/bin/php-cs-fixer fix",
-		"post-autoload-dump": [
-			"Roots\\Acorn\\ComposerScripts::postAutoloadDump"
-		],
-		"private-setup": [
-			"composer repo add satis composer https://satis.yard.nl",
-			"composer repo add satispress composer https://packagist.yard.nl/satispress/",
-			"composer require yard/brave-private-setup --dev",
-			"wp acorn setup:dependencies",
-			"wp acorn setup:deployer"
-		]
-	}
+  "name": "yard/brave",
+  "type": "project",
+  "license": "MIT",
+  "description": "WordPress boilerplate with Bedrock and Sage",
+  "support": {
+    "source": "https://github.com/yardinternet/brave"
+  },
+  "config": {
+    "optimize-autoloader": true,
+    "preferred-install": "dist",
+    "sort-packages": true,
+    "allow-plugins": {
+      "captainhook/hook-installer": true,
+      "composer/installers": true,
+      "dangoodman/composer-for-wordpress": true,
+      "roots/wordpress-core-installer": true
+    },
+    "platform": {
+      "php": "8.2"
+    }
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true,
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://wpackagist.org"
+    }
+  ],
+  "require": {
+    "php": ">=8.2",
+    "composer/installers": "^2.2",
+    "gravitykit/gravity-forms-zero-spam": "^1.7",
+    "johnbillion/user-switching": "^1.11",
+    "log1x/navi": "^3.1",
+    "log1x/poet": "^2.0",
+    "lukasbesch/bedrock-plugin-disabler": "^1.4",
+    "oscarotero/env": "^2.1",
+    "plugin/yard-gutenberg": "^1.5",
+    "roots/acorn": "^4.0",
+    "roots/bedrock-autoloader": "^1.0",
+    "roots/bedrock-disallow-indexing": "^2.0",
+    "roots/wordpress": "6.9.*",
+    "roots/wp-config": "^1.0",
+    "sentry/sentry-laravel": "^4.13",
+    "spatie/laravel-google-fonts": "^1.4",
+    "spatie/laravel-ignition": "^2.0",
+    "vlucas/phpdotenv": "^5.5",
+    "wp-cli/wp-cli-bundle": "^2.11",
+    "wp-media/imagify-plugin": "^2.2",
+    "wpackagist-plugin/cookie-law-info": "^3.2",
+    "wpackagist-plugin/generate-security-txt": "^1.0",
+    "wpackagist-plugin/relay": "^1.3",
+    "wpackagist-plugin/stream": "^4.0",
+    "wpackagist-plugin/two-factor": "^0.16.0",
+    "wpackagist-plugin/wp-seopress": "^8.1",
+    "yard/brave-components": "^1.2",
+    "yard/brave-csp": "^1.0",
+    "yard/brave-hooks": "^2.0",
+    "yard/config-expander": "^1.0",
+    "yard/data": "^1.0",
+    "yard/multisite-url-fixer": "^1.0",
+    "yard/nutshell": "^2.1",
+    "yard/query-block": "^1.0",
+    "yard/webmanifest": "^1.0",
+    "yard/wp-block-registrar": "^1.0",
+    "yard/wp-database": "^1.0",
+    "yard/wp-user-roles": "^2.0",
+    "yoast/duplicate-post": "^4.6"
+  },
+  "require-dev": {
+    "captainhook/captainhook": "^5.24",
+    "captainhook/hook-installer": "^1.0",
+    "johnbillion/query-monitor": "^3.20",
+    "yard/brave-scaffold": "^2.0",
+    "yard/lando-brave": "^1.0",
+    "yard/php-cs-fixer-rules": "^1.0"
+  },
+  "suggest": {
+    "gravity/gravityforms": "",
+    "deliciousbrains-plugin/wp-migrate-db-pro": "",
+    "plugin/yard-dashboard": "",
+    "wpengine/advanced-custom-fields-pro": "",
+    "ypackagist/facetwp": "",
+    "ypackagist/searchwp": "",
+    "ypackagist/wp-seopress-pro": "",
+    "yard/wp-deployer": "dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "web/app/themes/sage/app/"
+    }
+  },
+  "extra": {
+    "acorn": {
+      "providers": [
+        "App\\Providers\\ThemeServiceProvider"
+      ]
+    },
+    "installer-paths": {
+      "web/app/mu-plugins/{$name}/": [
+        "type:wordpress-muplugin"
+      ],
+      "web/app/plugins/{$name}/": [
+        "type:wordpress-plugin"
+      ],
+      "web/app/themes/{$name}/": [
+        "type:wordpress-theme"
+      ]
+    },
+    "wordpress-install-dir": "web/wp"
+  },
+  "scripts": {
+    "format": "./vendor/bin/php-cs-fixer fix",
+    "post-autoload-dump": [
+      "Roots\\Acorn\\ComposerScripts::postAutoloadDump"
+    ],
+    "private-setup": [
+      "composer repo add satis composer https://satis.yard.nl",
+      "composer repo add satispress composer https://packagist.yard.nl/satispress/",
+      "composer require yard/brave-private-setup --dev",
+      "wp acorn setup:dependencies",
+      "wp acorn setup:deployer"
+    ]
+  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5cffc25f83be2b4beb2950e1b0c987eb",
+    "content-hash": "92be7f836ccdd58eeed72dff24c83376",
     "packages": [
         {
             "name": "bordoni/phpass",
@@ -13279,6 +13279,24 @@
             "homepage": "https://wordpress.org/plugins/cookie-law-info/"
         },
         {
+            "name": "wpackagist-plugin/generate-security-txt",
+            "version": "1.0.12",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/generate-security-txt/",
+                "reference": "tags/1.0.12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/generate-security-txt.1.0.12.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/generate-security-txt/"
+        },
+        {
             "name": "wpackagist-plugin/relay",
             "version": "1.5.1",
             "source": {
@@ -13313,6 +13331,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/stream/"
+        },
+        {
+            "name": "wpackagist-plugin/two-factor",
+            "version": "0.16.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/two-factor/",
+                "reference": "tags/0.16.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/two-factor.0.16.0.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/two-factor/"
         },
         {
             "name": "wpackagist-plugin/wp-seopress",


### PR DESCRIPTION
- Clean Laravel-specific composer scripts if present.
- Require two-factor and generate-security-txt plugins, removes wordfence if present.
- Set PHP version and platform in composer.json. Defaults to 7.4, ups 8.1 to 8.2.
