### PR TITLE
feat: add displaySubtitle to card

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -11532,16 +11532,16 @@
         },
         {
             "name": "yard/query-block",
-            "version": "v1.4.1",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yardinternet/wp-query-block.git",
-                "reference": "5685ccd68554317c64dd32bd85c9ad638ceae19e"
+                "reference": "a5fc9bf1eb41250a7f64c77ac583afb094f87332"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yardinternet/wp-query-block/zipball/5685ccd68554317c64dd32bd85c9ad638ceae19e",
-                "reference": "5685ccd68554317c64dd32bd85c9ad638ceae19e",
+                "url": "https://api.github.com/repos/yardinternet/wp-query-block/zipball/a5fc9bf1eb41250a7f64c77ac583afb094f87332",
+                "reference": "a5fc9bf1eb41250a7f64c77ac583afb094f87332",
                 "shasum": ""
             },
             "require": {
@@ -11579,9 +11579,9 @@
             "description": "A query block for the Gutenberg editor.",
             "support": {
                 "issues": "https://github.com/yardinternet/wp-query-block/issues",
-                "source": "https://github.com/yardinternet/wp-query-block/tree/v1.4.1"
+                "source": "https://github.com/yardinternet/wp-query-block/tree/v1.5.0"
             },
-            "time": "2026-04-09T07:43:26+00:00"
+            "time": "2026-04-21T11:52:30+00:00"
         },
         {
             "name": "yard/webmanifest",
@@ -13934,15 +13934,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/web/app/themes/sage/app/View/Components/Card.php
+++ b/web/app/themes/sage/app/View/Components/Card.php
@@ -17,6 +17,7 @@ class Card extends Component
 		public ?bool $displayExcerpt = null,
 		public ?bool $displayImage = null,
 		public ?bool $displayLabel = null,
+		public ?bool $displaySubtitle = null,
 		public ?bool $thumbnailIsLogo = null,
 		public ?string $dateString = null,
 		public ?string $dateTime = null,
@@ -63,6 +64,7 @@ class Card extends Component
 		$this->displayExcerpt ??= true;
 		$this->displayImage ??= true;
 		$this->displayLabel ??= true;
+		$this->displaySubtitle ??= true;
 		$this->thumbnailIsLogo ??= ! $this->thumbnailUrl;
 	}
 

--- a/web/app/themes/sage/resources/views/components/card.blade.php
+++ b/web/app/themes/sage/resources/views/components/card.blade.php
@@ -33,7 +33,7 @@
 			@endif
 		</x-dynamic-tag>
 
-		@if ($subtitle)
+		@if ($displaySubtitle && $subtitle)
 			<p class="-mt-2 mb-3">{!! $subtitle !!}</p>
 		@endif
 

--- a/web/app/themes/sage/resources/views/vendor/yard-query-block/templates/default.blade.php
+++ b/web/app/themes/sage/resources/views/vendor/yard-query-block/templates/default.blade.php
@@ -14,7 +14,7 @@
 ])>
 	@forelse ($postDataCollection as $postData)
 		<x-dynamic-card :card="$postData->postType()" :postData="$postData" :displayDate="$attributes->displayDate()" :displayExcerpt="$attributes->displayExcerpt()" :displayImage="$attributes->displayImage()"
-			:displayLabel="$attributes->displayLabel()" />
+			:displayLabel="$attributes->displayLabel()" :displaySubtitle="$attributes->displaySubtitle()" />
 	@empty
 		<x-alert type="warning" class="col-span-full">
 			Geen resultaten gevonden.

--- a/web/app/themes/sage/resources/views/vendor/yard-query-block/templates/horizontal.blade.php
+++ b/web/app/themes/sage/resources/views/vendor/yard-query-block/templates/horizontal.blade.php
@@ -16,7 +16,7 @@
 ])>
 	@forelse ($postDataCollection as $postData)
 		<x-dynamic-card :card="$postData->postType()" :direction="Direction::FLUID" :postData="$postData" :displayDate="$attributes->displayDate()" :displayExcerpt="$attributes->displayExcerpt()"
-			:displayImage="$attributes->displayImage()" :displayLabel="$attributes->displayLabel()" />
+			:displayImage="$attributes->displayImage()" :displayLabel="$attributes->displayLabel()" :displaySubtitle="$attributes->displaySubtitle()" />
 	@empty
 		<x-alert type="warning" class="col-span-full">
 			Geen resultaten gevonden.


### PR DESCRIPTION
Het query block heeft een extra optie gekregen (https://github.com/yardinternet/wp-query-block/pull/142) dus in deze PR wordt dat toegepast.