### PR TITLE
feat: add template lock to back buttons in articles / use placeholder…

### DIFF
--- a/web/app/themes/sage/resources/scripts/editor/block-variations.jsx
+++ b/web/app/themes/sage/resources/scripts/editor/block-variations.jsx
@@ -99,9 +99,12 @@ const variationRegistry = [
 			},
 			scope: [ 'block', 'inserter' ],
 			innerBlocks: [
-				[ 'theme/back-button', { align: '' } ],
+				[
+					'theme/back-button',
+					{ align: '', lock: { move: true, remove: true } },
+				],
 				[ 'core/post-title', { level: 1 } ],
-				[ 'core/paragraph', { content: 'Voeg de inhoud toe' } ],
+				[ 'core/paragraph', { placeholder: 'Voeg de inhoud toe' } ],
 			],
 		},
 	},
@@ -141,9 +144,15 @@ const variationRegistry = [
 						className: 'layout-article-aside__article',
 					},
 					[
-						[ 'theme/back-button', { align: '' } ],
+						[
+							'theme/back-button',
+							{ align: '', lock: { move: true, remove: true } },
+						],
 						[ 'core/post-title', { level: 1 } ],
-						[ 'core/paragraph', { content: 'Voeg de inhoud toe' } ],
+						[
+							'core/paragraph',
+							{ placeholder: 'Voeg de inhoud toe' },
+						],
 					],
 				],
 				[
@@ -175,7 +184,7 @@ const variationRegistry = [
 								],
 								[
 									'core/paragraph',
-									{ content: 'Voeg de inhoud toe' },
+									{ placeholder: 'Voeg de inhoud toe' },
 								],
 							],
 						],


### PR DESCRIPTION
Deze PR voegt template locks toe aan de back buttons die met de article group variations worden toegevoegd om te voorkomen dat redacteuren deze verwijderen en er verschillen ontstaan tussen pagina's.

De dummy content binnen de groepen zijn daarnaast placeholders geworden zodat het makkelijker is om content te plakken.