### PR TITLE
fix: remove class from props in reset button component

### DIFF
--- a/web/app/themes/sage/resources/views/components/facetwp/reset-button.blade.php
+++ b/web/app/themes/sage/resources/views/components/facetwp/reset-button.blade.php
@@ -1,10 +1,9 @@
 @props([
-    'class' => '',
     'label' => 'Reset filters',
 ])
 
 <button
-	{{ $attributes->merge(['class' => 'js-brave-facetwp-btn-reset is-button is-button-subtle group flex w-full items-center justify-center gap-2 lg:w-fit']) }}
+	{{ $attributes->class(['js-brave-facetwp-btn-reset is-button is-button-subtle group flex w-full items-center justify-center gap-2 lg:w-fit'])->merge() }}
 	onclick="FWP.reset()">
 	<i class="fa-regular fa-redo-alt group-hover:rotate-320 transition-all duration-300" aria-hidden="true"></i>
 	{{ $label }}

--- a/web/app/themes/sage/resources/views/components/facetwp/reset-button.blade.php
+++ b/web/app/themes/sage/resources/views/components/facetwp/reset-button.blade.php
@@ -3,7 +3,7 @@
 ])
 
 <button
-	{{ $attributes->class(['js-brave-facetwp-btn-reset is-button is-button-subtle group flex w-full items-center justify-center gap-2 lg:w-fit'])->merge() }}
+	{{ $attributes->class(['js-brave-facetwp-btn-reset is-button is-button-subtle group flex w-full items-center justify-center gap-2 lg:w-fit']) }}
 	onclick="FWP.reset()">
 	<i class="fa-regular fa-redo-alt group-hover:rotate-320 transition-all duration-300" aria-hidden="true"></i>
 	{{ $label }}


### PR DESCRIPTION
Als `class` in `@props` staat wordt deze uit de `ComponentAttributeBag` gefilterd en is het niet mogelijk om van buitenaf een class mee te geven.

Verder is `class()` losgemaakt van `merge()`, dat maakt het makkelijker om conditionele classes toe te voegen net als met `@class`.