### PR TITLE
feat: move brave.wiki as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "brave.wiki"]
+	path = brave.wiki
+	url = git@github.com:yardinternet/brave.wiki.git


### PR DESCRIPTION
Normaal moet je losse git clone doen voor git wiki
Door de wiki als submodule toe te voegen staat de docs gewoon in je project.

handig voor `ctrl+f`, en AI-tooling kan het direct als context gebruiken.

MAAARRRR : 
Willen we dit wel? submodules is namelijk wel weer gelijk complixiteit die misschien in toekomst issues kan geven 🤷 