### PR TITLE
feat: pagination shared between facetwp and elasticsearch

### DIFF
--- a/web/app/themes/sage/resources/styles/base/variables.css
+++ b/web/app/themes/sage/resources/styles/base/variables.css
@@ -35,6 +35,36 @@
 	--spacing-size-6: calc( var( --spacing-size-5 ) * var( --spacing-ratio ) );
 	--spacing-size-7: calc( var( --spacing-size-6 ) * var( --spacing-ratio ) );
 
+	/* Pagination */
+	--pagination-item-bg-color-hover: var( --color-primary );
+	--pagination-item-color-hover: var( --color-white );
+	--pagination-item-gap-x: 0.5rem;
+	--pagination-item-gap-y: 1rem;
+	--pagination-item-margin: 2rem 0 0 0;
+	--pagination-item-radius: var( --radius-theme );
+	--pagination-item-size: 2.5rem;
+
+	/* Pagination - current */
+	--pagination-current-bg-color: transparent;
+	--pagination-current-color: var( --color-primary );
+	--pagination-current-underline-bg-color: var( --color-primary );
+
+	/* Pagination - prev */
+	--pagination-prev-bg-color: transparent;
+	--pagination-prev-bg-color-hocus: var( --color-primary );
+	--pagination-prev-border-color: var( --color-primary );
+	--pagination-prev-border-color-hocus: var( --color-primary );
+	--pagination-prev-color: var( --color-primary );
+	--pagination-prev-color-hocus: var( --color-white );
+
+	/* Pagination - next */
+	--pagination-next-bg-color: var( --color-primary );
+	--pagination-next-bg-color-hocus: transparent;
+	--pagination-next-border-color: var( --color-primary );
+	--pagination-next-border-color-hocus: var( --color-primary );
+	--pagination-next-color: var( --color-white );
+	--pagination-next-color-hocus: var( --color-primary );
+
 	/* Navigation */
 	--wp-admin-bar-height: var( --wp-admin--admin-bar--height, 0px );
 	--nav-bar-height: 80px;

--- a/web/app/themes/sage/resources/styles/components/facetwp.css
+++ b/web/app/themes/sage/resources/styles/components/facetwp.css
@@ -210,7 +210,7 @@
 
 	.facetwp-facet-pagination {
 		.facetwp-pager {
-			@apply mt-8 flex flex-wrap justify-center gap-x-2 gap-y-4;
+			@apply m-(--pagination-item-margin) flex flex-wrap justify-center gap-x-(--pagination-item-gap-x) gap-y-(--pagination-item-gap-y);
 
 			&:empty {
 				@apply mt-0;
@@ -218,16 +218,36 @@
 		}
 
 		.facetwp-page {
-			@apply relative m-0 flex size-10 items-center justify-center rounded-theme p-2 font-normal text-black no-underline transition-all;
+			@apply relative m-0 flex size-(--pagination-item-size) items-center justify-center rounded-(--pagination-item-radius) p-2 font-normal text-black no-underline transition-all;
 
-			&:not( .dots, .active ) {
+			&:not( .prev, .next, .dots, .active ) {
 				@variant hocus {
-					@apply bg-primary text-white;
+					@apply bg-(--pagination-item-bg-color-hover) text-(--pagination-item-color-hover);
 				}
 			}
 
 			&.active {
-				@apply bg-primary text-white;
+				@apply bg-(--pagination-current-bg-color) text-(--pagination-current-color);
+
+				&::after {
+					@apply absolute bottom-0 left-1/2 h-0.5 w-3/4 -translate-x-1/2 bg-(--pagination-current-underline-bg-color) content;
+				}
+			}
+
+			&.prev {
+				@apply border border-(--pagination-prev-border-color) bg-(--pagination-prev-bg-color) text-(--pagination-prev-color);
+
+				@variant hocus {
+					@apply border-(--pagination-prev-border-color-hocus) bg-(--pagination-prev-bg-color-hocus) text-(--pagination-prev-color-hocus);
+				}
+			}
+
+			&.next {
+				@apply border border-(--pagination-next-border-color) bg-(--pagination-next-bg-color) text-(--pagination-next-color);
+
+				@variant hocus {
+					@apply border-(--pagination-next-border-color-hocus) bg-(--pagination-next-bg-color-hocus) text-(--pagination-next-color-hocus);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Paginatie-stijlen maken nu gebruik van gedeelde CSS custom properties, zodat FacetWP en Elasticsearch paginatie visueel op elkaar aansluiten.

Zie ook: yardinternet/brave-scaffold#30


before: 
<img width="1186" height="319" alt="image" src="https://github.com/user-attachments/assets/871b934c-7f54-42fe-a61c-c8cc003d3ddc" />
<img width="1020" height="354" alt="image" src="https://github.com/user-attachments/assets/cf02e866-9431-4e78-9bb3-d5be91790085" />




After:
<img width="1399" height="330" alt="image" src="https://github.com/user-attachments/assets/7e4d2f24-e9ee-4732-b415-a5ebc26f4201" />
<img width="1011" height="359" alt="image" src="https://github.com/user-attachments/assets/98aa87cc-1691-4b2d-a8dc-d6ec3c32d1ca" />


Dingen zijn nu css vars, maar ook komt de styling meer overeen met wat ik vaak zie. (Met name de prev en next knop, dat vaak eentje een "outline" button is, en de ander een gevulde button.