### PR TITLE
fix: Add missing capability for editing SEO settings

### DIFF
--- a/web/app/themes/sage/config/user-roles.php
+++ b/web/app/themes/sage/config/user-roles.php
@@ -140,6 +140,7 @@ return [
 			'gravityforms_edit_entry_notes',
 		],
 		'seo_redirections' => [
+			'edit_posts',
 			'wpseo_bulk_edit',
 			'wpseo_manage_options',
 			'edit_redirection',


### PR DESCRIPTION
EDIT: Dit geeft helaas te brede rechten. Lijkt erop dat we via een hook ad-hoc rechten moeten geven op die specifieke SEO pagina. Dat ga ik proberen, en dan hier een comment toevoegen dat alleen deze caps niet afdoende zijn.