### PR TITLE
feat: add facetwp result count to mobile filters button

### DIFF
--- a/web/app/themes/sage/config/facetwp/facets/general_result_count_button.php
+++ b/web/app/themes/sage/config/facetwp/facets/general_result_count_button.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+	'name' => 'result_count_button',
+	'label' => 'Resultaten',
+	'type' => 'pager',
+	'pager_type' => 'counts',
+	'count_text_plural' => 'Bekijk resultaten <span class="text-xs">([total])</span>',
+	'count_text_singular' => 'Bekijk resultaat <span class="text-xs">(1)</span>',
+	'count_text_none' => 'Geen resultaten <span class="text-xs">(0)</span>',
+];

--- a/web/app/themes/sage/resources/views/components/facetwp/mobile-filters.blade.php
+++ b/web/app/themes/sage/resources/views/components/facetwp/mobile-filters.blade.php
@@ -32,8 +32,8 @@
 		<div class="z-2 sticky bottom-0 mt-auto flex gap-2 bg-white p-4">
 			<x-facetwp.reset-button />
 
-			<x-brave::dialog.trigger :dialogId="$dialogId" class="is-button w-full justify-center">
-				{{ __('Bekijk resultaten', 'sage') }}
+			<x-brave::dialog.trigger :dialogId="$dialogId" class="is-button w-full justify-center whitespace-nowrap">
+				{!! facetwp_display('facet', 'result_count_button') !!}
 			</x-brave::dialog.trigger>
 		</div>
 	</div>


### PR DESCRIPTION
## FacetWP result count 

Result count toegevoegd aan de "Bekijk resultaten" knop op mobiel. Zo zie je instantly hoeveel resultaten er zijn als je filtert:

<img width="383" height="704" alt="Screenshot 2026-06-08 at 11 27 30-edit" src="https://github.com/user-attachments/assets/c18d5993-8af3-4bfd-9f3f-3177b0418625" />

Geen resultaten: 
<img width="382" height="706" alt="Screenshot 2026-06-08 at 11 27 40" src="https://github.com/user-attachments/assets/20bbd070-cf11-45a8-b6ab-e9166ca60093" />
